### PR TITLE
Fix directory creation in unzip operation

### DIFF
--- a/internal/fileops/archive.go
+++ b/internal/fileops/archive.go
@@ -114,8 +114,8 @@ func UnpackZIP(src, dst string) error {
 			continue
 		}
 
-		// Создаем домашку для файла
-		if err := os.Mkdir(filepath.Dir(target), f.Mode()); err != nil {
+		// Создаем домашку для файла (всю вложенность)
+		if err := os.MkdirAll(filepath.Dir(target), f.Mode()); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
## Summary
- ensure nested directories exist when unpacking ZIP files

## Testing
- `go version` *(fails: golang toolchain download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6887962d1798832da373595ea8f496e2