### PR TITLE
Fix copy command overwrite prompt logic

### DIFF
--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -98,7 +98,7 @@ var copyCmd = &cobra.Command{
 
 		// . Проверяем наличие файла на dst
 		typ, err := fileops.PathType(config.Dst)
-		if err != nil && !config.Overwrite {
+		if err == nil && !config.Overwrite {
 			fmt.Printf("Файл %s уже существует, перезаписать (yes, no)?: ", config.Dst)
 			if inputs.Input() != "yes" {
 				fmt.Println("Отмена копирования.")


### PR DESCRIPTION
## Summary
- only prompt for overwrite when destination exists and overwrite flag is unset

## Testing
- `go test ./...` *(fails: unable to download toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_688795b3eb7c832d8015ef7d39636450